### PR TITLE
Fix incorrect configuration file paths in README.md and create_node.sh

### DIFF
--- a/testnet/intento-ics-test-1/README.md
+++ b/testnet/intento-ics-test-1/README.md
@@ -72,10 +72,10 @@ intentod init [your-moniker] --chain-id intento-ics-test-1
 From ./create_node.sh example script:
 
 ```bash
-config_toml="$HOME./intento/config/config.toml"
-client_toml="$HOME./intento/config/client.toml"
-app_toml="$HOME./intento/config/app.toml"
-genesis_json="$HOME./intento/config/genesis.json"
+config_toml="$HOME/.intento/config/config.toml"
+client_toml="$HOME/.intento/config/client.toml"
+app_toml="$HOME/.intento/config/app.toml"
+genesis_json="$HOME/.intento/config/genesis.json"
 
 ATOM="ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
 CHAINID="intento-ics-test-1"

--- a/testnet/intento-ics-test-1/create_node.sh
+++ b/testnet/intento-ics-test-1/create_node.sh
@@ -42,7 +42,7 @@ Restart=on-failure
 RestartSec=3
 LimitNOFILE=10000
 Environment="DAEMON_NAME=intentod"
-Environment="DAEMON_HOME=/home/ubuntu./intento"
+Environment="DAEMON_HOME=/home/ubuntu/.intento"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=true"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
 Environment="UNSAFE_SKIP_BACKUP=true"
@@ -60,13 +60,13 @@ sudo systemctl enable intentod.service
 sudo systemctl stop intentod.service
 
 # backup the old data if any
-if [ -d "$HOME./intento.bak" ]; then
+if [ -d "$HOME/.intento.bak" ]; then
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-    mv "$HOME./intento.bak" "$HOME./intento.bak_$TIMESTAMP"
+    mv "$HOME/.intento.bak" "$HOME/.intento.bak_$TIMESTAMP"
 fi
 # move the old data to the backup folder if there is one
-if [ -d "$HOME./intento" ]; then
-    mv "$HOME./intento" "$HOME./intento.bak"
+if [ -d "$HOME/.intento" ]; then
+    mv "$HOME/.intento" "$HOME/.intento.bak"
 fi
 
 # create the $HOME/go/bin folder if it doesn't exist
@@ -103,10 +103,10 @@ fi
 intentod init $MONIKER --chain-id $CHAINID
 
 # update config files and fetch genesis
-config_toml="$HOME./intento/config/config.toml"
-client_toml="$HOME./intento/config/client.toml"
-app_toml="$HOME./intento/config/app.toml"
-genesis_json="$HOME./intento/config/genesis.json"
+config_toml="$HOME/.intento/config/config.toml"
+client_toml="$HOME/.intento/config/client.toml"
+app_toml="$HOME/.intento/config/app.toml"
+genesis_json="$HOME/.intento/config/genesis.json"
 
 sed -i -E "s|cors_allowed_origins = \[\]|cors_allowed_origins = [\"\*\"]|g" $config_toml
 
@@ -127,7 +127,7 @@ sed -i -E "s|keyring-backend = \"os\"|keyring-backend = \"test\"|g" $client_toml
 curl https://raw.githubusercontent.com/trstlabs/networks/refs/heads/main/testnet/$CHAINID/genesis.json -o $genesis_json
 
 # setup cosmovisor
-mkdir -p $HOME./intento/cosmovisor/upgrades/$VERSION/bin && cp -a $HOME/go/bin/intentod $HOME./intento/cosmovisor/upgrades/$VERSION/bin/intentod && rm -rf $HOME./intento/cosmovisor/current && ln -sf $HOME./intento/cosmovisor/upgrades/$VERSION $HOME./intento/cosmovisor/current
+mkdir -p $HOME/.intento/cosmovisor/upgrades/$VERSION/bin && cp -a $HOME/go/bin/intentod $HOME/.intento/cosmovisor/upgrades/$VERSION/bin/intentod && rm -rf $HOME/.intento/cosmovisor/current && ln -sf $HOME/.intento/cosmovisor/upgrades/$VERSION $HOME/.intento/cosmovisor/current
 
 # start the node
 sudo systemctl start intentod.service


### PR DESCRIPTION
This PR fixes incorrect file paths in the configuration script. The current paths reference `"$HOME./intento/config/..."`, but the correct directory (as per the actual structure) is `"$HOME/.intento/config/..."`.  

#### **Files Updated:**  
- **`testnet/intento-ics-test-1/README.md`** → Updated incorrect directory references in the testnet guide.  
- **`testnet/intento-ics-test-1/create_node.sh`** → Fixed the script to use the correct path for configuration files.  

These changes ensure that users and scripts correctly reference the **`.intento/config/`** directory, preventing setup errors.